### PR TITLE
Improve Carthage support

### DIFF
--- a/IDNowSDKCore-Xcode_10.2.json
+++ b/IDNowSDKCore-Xcode_10.2.json
@@ -1,0 +1,3 @@
+{
+    "3.14.0": "https://github.com/idnow/de.idnow.ios.sdk/raw/master/IDnow-platform-iOS-Xcode_10.2/IDNowSDKCore.framework.zip"
+}

--- a/IDNowSDKCore-Xcode_11.1.json
+++ b/IDNowSDKCore-Xcode_11.1.json
@@ -1,0 +1,3 @@
+{
+    "3.14.0": "https://github.com/idnow/de.idnow.ios.sdk/raw/master/IDnow-platform-iOS-Xcode_11.1/IDNowSDKCore.framework.zip"
+}

--- a/IDNowSDKCore-Xcode_11.2.1.json
+++ b/IDNowSDKCore-Xcode_11.2.1.json
@@ -1,0 +1,3 @@
+{
+    "3.14.0": "https://github.com/idnow/de.idnow.ios.sdk/raw/master/IDnow-platform-iOS-Xcode_11.2.1/IDNowSDKCore.framework.zip"
+}

--- a/IDNowSDKCore.json
+++ b/IDNowSDKCore.json
@@ -1,5 +1,0 @@
-{
-    "3.14.0-Xcode_10.2": "https://github.com/idnow/de.idnow.ios.sdk/raw/master/IDnow-platform-iOS-Xcode_10.2/IDNowSDKCore.framework.zip",
-    "3.14.0-Xcode_11.1": "https://github.com/idnow/de.idnow.ios.sdk/raw/master/IDnow-platform-iOS-Xcode_11.1/IDNowSDKCore.framework.zip",
-    "3.14.0-Xcode_11.2.1": "https://github.com/idnow/de.idnow.ios.sdk/raw/master/IDnow-platform-iOS-Xcode_11.2.1/IDNowSDKCore.framework.zip"
-}

--- a/IDNowSDKCore.json
+++ b/IDNowSDKCore.json
@@ -1,0 +1,5 @@
+{
+    "3.14.0-Xcode_10.2": "https://github.com/idnow/de.idnow.ios.sdk/raw/master/IDnow-platform-iOS-Xcode_10.2/IDNowSDKCore.framework.zip",
+    "3.14.0-Xcode_11.1": "https://github.com/idnow/de.idnow.ios.sdk/raw/master/IDnow-platform-iOS-Xcode_11.1/IDNowSDKCore.framework.zip",
+    "3.14.0-Xcode_11.2.1": "https://github.com/idnow/de.idnow.ios.sdk/raw/master/IDnow-platform-iOS-Xcode_11.2.1/IDNowSDKCore.framework.zip"
+}

--- a/OpenCV2.json
+++ b/OpenCV2.json
@@ -1,0 +1,3 @@
+{
+    "3.4.8": "https://github.com/opencv/opencv/releases/download/3.4.8/opencv-3.4.8-ios-framework.zip"
+}

--- a/README.md
+++ b/README.md
@@ -52,29 +52,32 @@ end
 ### Carthage 
 
 * Create a Cartfile 
-* Add the following to the Cartfile : (Xcode 10.2)
+* Add the following to the Cartfile: (Xcode 10.2)
 ```
-github "idnow/de.idnow.ios.sdk" "3.14.0-Xcode_10.2"
-github "Alamofire/Alamofire" "4.8.2"
-github "getsentry/sentry-cocoa" "4.1.0"
+binary "https://raw.githubusercontent.com/idnow/de.idnow.ios.sdk/master/IDNowSDKCore.json" "3.14.0-Xcode_10.2"
+binary "https://raw.githubusercontent.com/idnow/de.idnow.ios.sdk/master/OpenCV2.json"
+github "Alamofire/Alamofire" ~> 4.9
+github "getsentry/sentry-cocoa" ~> 4.4
+```
+* Add the following to the Cartfile: (Xcode 11.1)
+```
+binary "https://raw.githubusercontent.com/idnow/de.idnow.ios.sdk/master/IDNowSDKCore.json" "3.14.0-Xcode_11.1"
+binary "https://raw.githubusercontent.com/idnow/de.idnow.ios.sdk/master/OpenCV2.json"
+github "Alamofire/Alamofire" ~> 4.9
+github "getsentry/sentry-cocoa" ~> 4.4
+```
+* Add the following to the Cartfile: (Xcode 11.2.1) 
+```
+binary "https://raw.githubusercontent.com/idnow/de.idnow.ios.sdk/master/IDNowSDKCore.json" "3.14.0-Xcode_11.2.1"
+binary "https://raw.githubusercontent.com/idnow/de.idnow.ios.sdk/master/OpenCV2.json"
+github "Alamofire/Alamofire" ~> 4.9
+github "getsentry/sentry-cocoa" ~> 4.4
+```
 
+* Run:
 ```
-* Add the following to the Cartfile : (Xcode 11.1)
+carthage update --platform iOS
 ```
-github "idnow/de.idnow.ios.sdk" "3.14.0-Xcode_11.1"
-github "Alamofire/Alamofire" "4.8.2"
-github "getsentry/sentry-cocoa" "4.1.0"
-
-```
-* Add the following to the Cartfile : (Xcode 11.2.1) 
-```
-github "idnow/de.idnow.ios.sdk" "3.14.0-Xcode_11.2.1"
-github "Alamofire/Alamofire" "4.8.2"
-github "getsentry/sentry-cocoa" "4.1.0"
-
-```
-
-* Run carthage update --platform iOS
 
 * Drag the Frameworks needed (IDNowSDKCore.framework/ Alamofire.framework / Sentry.framework) from the Carthage/Build/iOS subfolder to ‘Linked Frameworks and Libraries’ (Target configuration -> General tab)
 
@@ -84,12 +87,11 @@ github "getsentry/sentry-cocoa" "4.1.0"
 
 * In the Shell text field, type : /usr/local/bin/carthage copy-frameworks
 
-* Under Input Files add : 
+* Under Input Files add: 
 ```
 $(SRCROOT)/Carthage/Build/iOS/IDNowSDKCore.framework
 $(SRCROOT)/Carthage/Build/iOS/Alamofire.framework
 $(SRCROOT)/Carthage/Build/iOS/Sentry.framework
-
 ```  
 * Check the (Run Script only when installing)
 
@@ -128,17 +130,9 @@ public func start(token: String, preferredLanguage: String = default, fromViewCo
 Swift
 
 ```
-IDNowSDK.shared.start(token: tokenTextField!.text!, fromViewController: self, listener:
-{ (result: IDNowSDK.IdentResult, message: String) in
-
-print ("SDK finished")
-self.progress.isHidden = true
-self.progress.stopAnimating()
-
-if (result == IDNowSDK.IdentResult.ERROR) 
-{
-self.showAlert(text: message)
-}
+IDNowSDK.shared.start(token: identId, fromViewController: viewController) { (result, message) in
+    print ("IDnow SDK finished with result: \(result)")
+    print ("IDnow SDK message: \(message)")
 }
 ```
 
@@ -147,17 +141,16 @@ Objective-C
 ```
 IDNowSDK* sdk = [[IDNowSDK alloc] init];
 
-void (^idnowResultListener)(enum IdentResult identResult, NSString * _Nonnull) =
-^(enum IdentResult result, NSString* message) {
-NSLog( @"SDK finished");
+void (^idnowResultListener)(enum IdentResult identResult, NSString * _Nonnull) = ^(enum IdentResult result, NSString* message) {
+    NSLog( @"SDK finished");
 
-if (result == IdentResultERROR) {
-// show result in debug log
-}
+    if (result == IdentResultERROR) {
+        // show result in debug log
+    }
 
-if( result == IdentResultFINISHED ) {
-// show result in debug log
-}
+    if( result == IdentResultFINISHED ) {
+        // show result in debug log
+    }
 };
 
 [sdk startWithToken:@"INTERNAL_TOKEN" preferredLanguage:@"en" fromViewController:self listener:idnowResultListener];

--- a/README.md
+++ b/README.md
@@ -54,21 +54,21 @@ end
 * Create a Cartfile 
 * Add the following to the Cartfile: (Xcode 10.2)
 ```
-binary "https://raw.githubusercontent.com/idnow/de.idnow.ios.sdk/master/IDNowSDKCore.json" "3.14.0-Xcode_10.2"
+binary "https://raw.githubusercontent.com/idnow/de.idnow.ios.sdk/master/IDNowSDKCore-Xcode_10.2.json"
 binary "https://raw.githubusercontent.com/idnow/de.idnow.ios.sdk/master/OpenCV2.json"
 github "Alamofire/Alamofire" ~> 4.9
 github "getsentry/sentry-cocoa" ~> 4.4
 ```
 * Add the following to the Cartfile: (Xcode 11.1)
 ```
-binary "https://raw.githubusercontent.com/idnow/de.idnow.ios.sdk/master/IDNowSDKCore.json" "3.14.0-Xcode_11.1"
+binary "https://raw.githubusercontent.com/idnow/de.idnow.ios.sdk/master/IDNowSDKCore-Xcode_11.1.json"
 binary "https://raw.githubusercontent.com/idnow/de.idnow.ios.sdk/master/OpenCV2.json"
 github "Alamofire/Alamofire" ~> 4.9
 github "getsentry/sentry-cocoa" ~> 4.4
 ```
 * Add the following to the Cartfile: (Xcode 11.2.1) 
 ```
-binary "https://raw.githubusercontent.com/idnow/de.idnow.ios.sdk/master/IDNowSDKCore.json" "3.14.0-Xcode_11.2.1"
+binary "https://raw.githubusercontent.com/idnow/de.idnow.ios.sdk/master/IDNowSDKCore-Xcode_11.2.1.json"
 binary "https://raw.githubusercontent.com/idnow/de.idnow.ios.sdk/master/OpenCV2.json"
 github "Alamofire/Alamofire" ~> 4.9
 github "getsentry/sentry-cocoa" ~> 4.4


### PR DESCRIPTION
Right now using Carthage as described in the README.md (`github "idnow/de.idnow.ios.sdk" "3.14.0-Xcode_11.2.1"`) downloads the whole repository with the specified tag and tries to compile an Xcode project, failing.

This framework is distributed as a compiled binary and, following [Carthage documentation](https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#binary-only-frameworks), we need a JSON specifying the location of this binary.

This PR adds working support for Carthage by adding a JSON for each version of Xcode being used to compile IDNowSDKCore.framework and updating the README.md with updated instructions.

The links in the JSON files point to the master branch, these could be pointing to the release links or to any commit's, up to you to decide how you handle this.

The "IDNowSDKCore.framework.zip" releases right now are zipped Carthage folders. These can't be used by Carthage, the "IDNowSDKCore.framework.zip" has to be in the root of the ZIP file. Also, these compilations embed the dependencies, this is not necessary as those are added through Carthage as well. Finally, these frameworks appear to include support for the iOS simulator which is stripped in the compilations on the repository. In conclusion, ideally the compilations should not embed any dependencies but simulator support would be nice.

I hope I saved you some work and some complaints. Thanks!